### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
+          cache: npm
       - uses: actions/cache@v1
         with:
           path: ~/.npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
+          cache: npm
       - uses: actions/cache@v2
         with:
           path: ~/.npm


### PR DESCRIPTION
## Description
    Add `cache` to workflows using `actions/setup-node`
    
    ## Context
    `setup-node` GitHub Action just released a new option to add cache to steps using it.
    Deteails here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

    🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action),
    feel free to run it in your GitHub user/org repositories! 💪🏾
    